### PR TITLE
add show/hide on error message on password reset page

### DIFF
--- a/templates/registration/password_reset_confirm.html
+++ b/templates/registration/password_reset_confirm.html
@@ -53,7 +53,7 @@
           <p class="message-copy">Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Lorem ipsum dolor sit amet, consectetuer adipiscing elit.</p>
         </div>
 
-        <div role="alert" class="status message submission-error">
+        <div role="alert" class="status message submission-error" style="display: {% if err_msg %}block{% else %}None{% endif %}">
           <h3 class="message-title">The following errors occured while processing your registration: </h3>
           <ul class="message-copy">
             {% if err_msg %}


### PR DESCRIPTION
Sorry, @antoviaque, in the themed password reset page, I had to reconcile an edit which was applied to the open edX Django template (the show/hide of the error message div).
