### PR TITLE
Nested List Indentation

### DIFF
--- a/lms/static/sass/xblocks/drag_and_drop.scss
+++ b/lms/static/sass/xblocks/drag_and_drop.scss
@@ -151,4 +151,17 @@
         content: "\f06a";
         color: #ff143d;
     }
+
+    //Drag & Drop list indentation
+    ul{
+        margin-left: 20px;
+        padding: 0;
+    }
+
+    //To normalize extra indentation of nested list as it is being in use at number of places and a bit difficult
+    //task to relocate all the <ul><ul></ul></ul> structure to make it a valid markup. Issue # MCKIN-6959
+    ul > ul{
+        margin-left: 0;
+        padding: 0;
+    }
 }}


### PR DESCRIPTION
- Fixed extra indentation of nested list

Steps to verify changes:
- Add a nested "ul" in  drag & drop html section

- Inner "ul" should have no indentation and outer "ul" should have 20px margin from left

@bradenmacdonald Please get this PR reviewed