### PR TITLE
MCKIN-7493 Moves the problem_builder apros.css into the theme

### DIFF
--- a/lms/static/sass/apros-xblocks.scss
+++ b/lms/static/sass/apros-xblocks.scss
@@ -1,2 +1,3 @@
 @import 'base/variables';
 @import 'xblocks/drag_and_drop';
+@import 'xblocks/problem_builder';

--- a/lms/static/sass/xblocks/problem_builder.scss
+++ b/lms/static/sass/xblocks/problem_builder.scss
@@ -1,0 +1,40 @@
+// Overrides for Problem Builder
+// from https://github.com/open-craft/problem-builder/blob/7e76920/problem_builder/public/themes/apros.css
+.mentoring {
+    .questionnaire {
+        .choice-tips, .feedback {
+            // Avoid a global reset to border-box found on Apros
+            box-sizing: content-box;  
+        }
+        .choice-label {
+            // Fill the full page width for MRC/MCQ choices
+            width: 100%
+        }
+    }
+    .title h3 {
+        // Same as h2.main in Apros, amended to h3
+        color: #66a5b5;
+    }
+    h4 {
+        text-transform: uppercase;
+    }
+}
+
+.themed-xblock.mentoring {
+    .choices-list .choice-selector {
+        padding: 4px 3px 0 3px;
+        font-size: 16px;
+    }
+    .sb-review-score {
+        margin-left: 40px;
+        margin-top: 15px;
+    }
+    .review-tips-list li {
+        margin-left: 1.8em;
+        padding-left: 0;
+    }
+    .copyright {
+        // Hide the copyright message
+        display: none;
+    }
+}


### PR DESCRIPTION
Converts the problem-builder [themes/apros.css](https://github.com/open-craft/problem-builder/blob/master/problem_builder/public/themes/apros.css) file to SCSS, and moves it into this theme repo.

**JIRA tickets**: [MCKIN-7493](https://edx-wiki.atlassian.net/browse/MCKIN-7493)

**Dependencies**: https://github.com/open-craft/problem-builder/pull/192

**Merge deadline**: ASAP

**Testing instructions**:

1. Checkout this updated theme and rebuild LMS assets: `paver update_assets`
1. Install the branch from https://github.com/open-craft/problem-builder/pull/192 to ensure that it is no longer providing the removed `apros.css` file.
1. Check the custom apros theme features are retained, e.g as described on https://github.com/open-craft/problem-builder/pull/141

**Reviewers**
- [ ] @xitij2000 

CC @mtyaka 
