### PR TITLE
MCKIN-7493 Fix issues with theme on Problem Builder css

### DIFF
--- a/lms/static/sass/xblocks/problem_builder.scss
+++ b/lms/static/sass/xblocks/problem_builder.scss
@@ -1,25 +1,5 @@
 // Overrides for Problem Builder
 // from https://github.com/open-craft/problem-builder/blob/7e76920/problem_builder/public/themes/apros.css
-.mentoring {
-    .questionnaire {
-        .choice-tips, .feedback {
-            // Avoid a global reset to border-box found on Apros
-            box-sizing: content-box;  
-        }
-        .choice-label {
-            // Fill the full page width for MRC/MCQ choices
-            width: 100%
-        }
-    }
-    .title h3 {
-        // Same as h2.main in Apros, amended to h3
-        color: #66a5b5;
-    }
-    h4 {
-        text-transform: uppercase;
-    }
-}
-
 .themed-xblock.mentoring {
     .choices-list .choice-selector {
         padding: 4px 3px 0 3px;
@@ -36,5 +16,18 @@
     .copyright {
         // Hide the copyright message
         display: none;
+    }
+    .questionnaire {
+        .choice-tips, .feedback {
+            // Avoid a global reset to border-box found on Apros
+            box-sizing: content-box;  
+        }
+    }
+    .title h3 {
+        // Same as h2.main in Apros, amended to h3
+        color: #66a5b5;
+    }
+    h4 {
+        text-transform: uppercase;
     }
 }


### PR DESCRIPTION
Fixes issue with the theme. Move all styles inside themed-xblock, to make sure they always take precedence. Remove width:100% from .choice-label class.

**JIRA tickets**: MCKIN-7493

**Merge deadline:** ASAP

**Testing instructions**:

Check on the QA server by updating this file manually on the browser (using the link provided by MCKinsey)
Check on your devstack with a similar problem.

**Reviewers**

 @xitij2000 

**Before**:

<img width="712" alt="before" src="https://user-images.githubusercontent.com/1637193/41877258-a1c25bf8-789e-11e8-9dd1-6fa0a2f34af6.png">

**After**:

<img width="726" alt="after" src="https://user-images.githubusercontent.com/1637193/41877265-a7e6b47a-789e-11e8-8d6f-90a23f987737.png">

