### PR TITLE
MCKIN-8801, MCKIN-8802, MCKIN-8559 Chat & DnD fixes

### DIFF
--- a/lms/static/sass/apros-xblocks.scss
+++ b/lms/static/sass/apros-xblocks.scss
@@ -2,3 +2,4 @@
 @import 'xblocks/drag_and_drop';
 @import 'xblocks/problem_builder';
 @import 'xblocks/image_explorer';
+@import 'xblocks/chat';

--- a/lms/static/sass/xblocks/chat.scss
+++ b/lms/static/sass/xblocks/chat.scss
@@ -1,0 +1,14 @@
+// Overrides for chat:
+@import '../base/variables';
+
+// The image rotation in chat doesn't work correctly so have to overwrite the CSS
+.chat-block .image-overlay img {
+  position: absolute !important;
+  max-width: 100% !important;
+  max-height: calc(100% - 96px) !important;
+  transform: translate(-50%, -50%) !important;
+  width: auto !important;
+  height: 1000px !important;
+  top: calc(50% + 50px) !important;
+  left: 50% !important;
+}

--- a/lms/static/sass/xblocks/drag_and_drop.scss
+++ b/lms/static/sass/xblocks/drag_and_drop.scss
@@ -36,7 +36,8 @@
         background-color: transparent;
     }
 
-    .feedback p::before {
+    .feedback p::before,
+    .feedback p::after {
         display: none;
     }
 
@@ -54,6 +55,13 @@
 .rtl .themed-xblock.xblock--drag-and-drop .actions-toolbar .action-toolbar-item.sidebar-buttons {
     float: left;
     padding-left: -5px;
+}
+
+// Default of this series of tags is set to text-align left in LMS
+.rtl {
+    h1, h2, h3, h4, h5, h6, p, label {
+        text-align: right;
+    }
 }
 
 @include dnd-mobile-only {


### PR DESCRIPTION
- Fixed text alignment in DnD feedback text

**Steps to produce**
- Add DnD standard mode in APROS environment
- Feedback text should not have any icon

**Before**

![dndv2-before](https://user-images.githubusercontent.com/7480659/48955577-64201580-ef70-11e8-8014-690bc212bff1.png)

**After**

![dndv2-after](https://user-images.githubusercontent.com/7480659/48955592-77cb7c00-ef70-11e8-9f8f-8859e8008d0f.png)


**Ticket:**
[https://edx-wiki.atlassian.net/browse/MCKIN-8802](https://edx-wiki.atlassian.net/browse/MCKIN-8802)

_____________________________________________________________

- Fixed image rotation in chat

**Steps to produce**
- Import the course I sent to @xitij2000 in email
- Go to Lesson4 Module7
- Select 4 user message response 
- Click the image. It should be visible without cutting from any edge

**Before**

![chat-before](https://user-images.githubusercontent.com/7480659/48955618-8c0f7900-ef70-11e8-9800-df229fdc5f50.png)

**After**

![chat-after](https://user-images.githubusercontent.com/7480659/48955631-9af62b80-ef70-11e8-8e30-80ee38e4330e.png)

**Ticket**
[https://edx-wiki.atlassian.net/browse/MCKIN-8559](https://edx-wiki.atlassian.net/browse/MCKIN-8559)

_____________________________________________________________

- Fixed text alignment of DnD feedback text

**Steps to produce**
- Add DnD standard mode in APROS environment
- Feedback text should be right in RTL(You can add class"rtl" to body & dir="rtl" to HTML tags to test in RTL)

**After**

![text-align-after](https://user-images.githubusercontent.com/7480659/48955756-35ef0580-ef71-11e8-8ebb-8109c5278ba6.png)

**Ticket**
[https://edx-wiki.atlassian.net/browse/MCKIN-8801](https://edx-wiki.atlassian.net/browse/MCKIN-8801)

_____________________________________________________________
Please review this PR for APROS only
@viadanna | @xitij2000 | @abhishek-bahuguna1520 