### PR TITLE
fixes

### DIFF
--- a/lms/static/sass/xblocks/drag_and_drop.scss
+++ b/lms/static/sass/xblocks/drag_and_drop.scss
@@ -362,7 +362,7 @@ body.new-theme {
                                     font-size: 0.875rem;
                                     background: $light-green;
                                     color: $black;
-                                    padding: 20px 0 5px;
+                                    padding: 20px 10px 5px;
                                     margin: 10px 0 10px;
                                 }
 
@@ -398,7 +398,7 @@ body.new-theme {
                                     .popup-content-incorrect {
                                         background: $light-red;
                                         color: $black;
-                                        padding: 20px 0 5px;
+                                        padding: 20px 10px 5px;
                                     }
                                 }
                             }

--- a/lms/static/sass/xblocks/ooyala_videos.scss
+++ b/lms/static/sass/xblocks/ooyala_videos.scss
@@ -157,12 +157,15 @@ body.new-theme {
             }
 
             .transcript-header {
+                display: none;
                 .language-tracks {
                     ul {
                         li {
                             color: $mckinsey-default-link !important;
                             font-size: 1rem;
                             font-weight: 400;
+                            list-style: none;
+                            list-style-type: none;
 
                             &.selected {
                                 color: #2E2D39 !important;

--- a/lms/static/sass/xblocks/problem_builder.scss
+++ b/lms/static/sass/xblocks/problem_builder.scss
@@ -588,6 +588,7 @@ body.new-theme {
                 color: $gray;
                 padding: 15px 10px;
                 font-weight: 200;
+                word-break: break-word;
                 &::before{
                     vertical-align: 0px;
                     font-family: 'Material Icons';


### PR DESCRIPTION
Hide transcript is visible to learners before oyala video loads  - fixed
Extra dot appear with languages in transcripts. - fixed
Drag and drop- padding if popup text is very big
FTR - break a long word to not go out of screen