### PR TITLE
MCKIN-10438: reset checboxes and radio buttons on assessment try again

### DIFF
--- a/lms/static/js/apros-xblocks.js
+++ b/lms/static/js/apros-xblocks.js
@@ -3,7 +3,11 @@ $(function () {
   $(document).on('change', '.new-theme input[type=radio]', function(e) {
     var parent = $(e.target).parents('[data-block-type="pb-mcq"], [data-block-type="adventure"]');
     $(parent).find(".choice-selector").removeClass("selected");
-    $(e.target).parent().addClass("selected");
+    if (e.target.checked) {
+      $(e.target).parent().addClass("selected");
+    } else {
+      $(e.target).parent().removeClass("selected");
+    }
   });
 
   $(document).on('change', '.new-theme [data-block-type="pb-mrq"] input[type="checkbox"], .new-theme .post-options input[type="checkbox"]', function (e) {
@@ -17,13 +21,21 @@ $(function () {
   $(document).on('change', '.new-theme input[type=radio]', function (e) {
     var parent = $(e.target).parents('[data-block-type="poll"]');
     $(parent).find(".poll-input-container").removeClass("selected");
-    $(e.target).parent().addClass("selected");
+    if (e.target.checked) {
+      $(e.target).parent().addClass("selected");
+    } else {
+      $(e.target).parent().removeClass("selected");
+    }
   });
 
   $(document).on('change', '.new-theme input[type=radio]', function (e) {
     var parent = $(e.target).parents('.field-label, .survey-row');
     $(parent).find(".selected").removeClass("selected");
-    $(e.target).parent().addClass("selected");
+    if (e.target.checked) {
+      $(e.target).parent().addClass("selected");
+    } else {
+      $(e.target).parent().removeClass("selected");
+    }
   });
 
   // Add selected class to selected poll results when appended to DOM


### PR DESCRIPTION
In new UI when user selects try again in assessment, selection made during previous attempt to not clear. Because in new UI design team is using custom checkboxes/radio buttons, On try again click problem-builder xblock clearSelections function clears checkboxes/radio buttons using prop which does not trigger change event, [PR](https://github.com/open-craft/problem-builder/pull/229) triggers that change event. This PR handles that change event and clears custom made checkboxes/radio buttons in new UI.

Related Problem Builder PR: https://github.com/open-craft/problem-builder/pull/229