### PR TITLE
MCKIN-9026 IE Retain check mark size in mobile view

### DIFF
--- a/lms/static/sass/xblocks/image_explorer.scss
+++ b/lms/static/sass/xblocks/image_explorer.scss
@@ -249,14 +249,6 @@ body.new-theme {
         .image-explorer-wrapper {
           .image-explorer-hotspot {
 
-            &:before {
-              font-size: 22px;
-              width: 14px;
-              height: 14px;
-              line-height: 14px;
-
-            }
-
             .image-explorer-hotspot-reveal {
               width: 90% !important;
               height: 74% !important;


### PR DESCRIPTION
Jira ticket: https://edx-wiki.atlassian.net/browse/MCKIN-9026

Css for mobile view actually makes the checkmarks too small.
Removing the css so the checkmarks retain their size in desktop and mobile.