### PR TITLE
MCKIN-12180 | Remove :after from the Image-Explorer popup cross button.

### DIFF
--- a/lms/static/sass/xblocks/image_explorer.scss
+++ b/lms/static/sass/xblocks/image_explorer.scss
@@ -179,10 +179,8 @@ body.new-theme {
               &:hover {
                 background-color: transparent !important;
               }
-
-              &:after {
+              i{
                 font-family: "Material Icons";
-                content: "\e14c";
                 color: $gray;
                 font-size: 1.125rem;
               }


### PR DESCRIPTION
MCKIN-12180 | Remove :after from the Image-Explorer popup cross button.