### PR TITLE
MCKIN-12927 | make the Cross Icon Visible on IE x block popup.

### DIFF
--- a/lms/static/sass/xblocks/image_explorer.scss
+++ b/lms/static/sass/xblocks/image_explorer.scss
@@ -177,10 +177,12 @@ body.new-theme {
               &:hover {
                 background-color: transparent !important;
               }
-              i{
+              &:after {
                 font-family: "Material Icons";
+                content: "\e14c";
                 color: $gray;
                 font-size: 1.125rem;
+                font-weight: 300;
               }
             }
 


### PR DESCRIPTION
MCKIN-12927 | make the Cross Icon Visible and arrange the sequence for accessibility.

connects https://github.com/edx-solutions/xblock-image-explorer/pull/74