### PR TITLE
MCKIN-23037 - Remove transcript header `display:none`

### DIFF
--- a/lms/static/sass/xblocks/ooyala_videos.scss
+++ b/lms/static/sass/xblocks/ooyala_videos.scss
@@ -148,7 +148,6 @@ body.new-theme {
         }
 
         .transcript-header {
-            display: none;
 
             .language-tracks {
                 ul {


### PR DESCRIPTION
Remove transcript header `display:none`. After changes into XBlock markup this is now not needed. 