### PR TITLE
MCKIN-27135 content overlapping in inline discussion

### DIFF
--- a/lms/static/sass/discussion/inline-discussion.scss
+++ b/lms/static/sass/discussion/inline-discussion.scss
@@ -1968,6 +1968,10 @@ body.new-theme {
                     }
 
                     .discussion-post {
+                        .post-header {
+                            height: auto !important;
+                        }
+
                         .post-header-actions {
                             top: 65px;
 
@@ -2020,6 +2024,10 @@ body.new-theme {
                                 }
                             }
 
+                        }
+
+                        .post-body {
+                            max-width: 100%;
                         }
                     }
 


### PR DESCRIPTION
Post description and Title is overlapping when the description/title has large content on RN App.